### PR TITLE
chore: pin the version of the github runner

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:


### PR DESCRIPTION
## Description
This PR pins the version used in the Github Runners.

## Changes
* Version pinned.

## Testing
You can verify the new behaviour by checking the pipelines.

## Feedback Requests
I would like feedback on anything.

---

[gitbook: about PRs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews)